### PR TITLE
Limit device forces

### DIFF
--- a/src/devices/CDeltaDevices.cpp
+++ b/src/devices/CDeltaDevices.cpp
@@ -1557,7 +1557,7 @@ bool cDeltaDevice::getGripperAngleRad(double& a_angle)
 //==============================================================================
 bool cDeltaDevice::setForceAndTorqueAndGripperForce(const cVector3d& a_force,
                                                    const cVector3d& a_torque,
-                                                   double a_gripperForce)
+                                                   const double a_gripperForce)
 {
     // check if the system is available
     if (!m_deviceReady) return (C_ERROR);

--- a/src/devices/CDeltaDevices.h
+++ b/src/devices/CDeltaDevices.h
@@ -207,7 +207,7 @@ public:
     virtual bool getUserSwitches(unsigned int& a_userSwitches);
 
     //! This method sends a force, torque, and gripper force to the haptic device.
-    virtual bool setForceAndTorqueAndGripperForce(const cVector3d& a_force, const cVector3d& a_torque, double a_gripperForce);
+    virtual bool setForceAndTorqueAndGripperForce(const cVector3d& a_force, const cVector3d& a_torque, const double a_gripperForce);
 
 
     //--------------------------------------------------------------------------

--- a/src/devices/CGenericHapticDevice.h
+++ b/src/devices/CGenericHapticDevice.h
@@ -368,7 +368,7 @@ public:
     bool  setForceAndTorque(const cVector3d& a_force, const cVector3d& a_torque) { return (setForceAndTorqueAndGripperForce(a_force, a_torque, 0.0)); }
 
     //! This method sends a force [N], torque [N*m], and gripper force [N] command to the haptic device.
-    virtual bool setForceAndTorqueAndGripperForce(const cVector3d& a_force, const cVector3d& a_torque, double a_gripperForce) { cSleepMs(1); return (m_deviceReady); }
+    virtual bool setForceAndTorqueAndGripperForce(const cVector3d& a_force, const cVector3d& a_torque, const double a_gripperForce) { cSleepMs(1); return (m_deviceReady); }
 
 
     //--------------------------------------------------------------------------

--- a/src/devices/CMyCustomDevice.cpp
+++ b/src/devices/CMyCustomDevice.cpp
@@ -594,21 +594,33 @@ bool cMyCustomDevice::setForceAndTorqueAndGripperForce(const cVector3d& a_force,
 
     bool result = C_SUCCESS;
 
+	// clamp forces and torques to prevent device damage
+	cVector3d force(a_force);
+	force.clamp(m_specifications.m_maxLinearForce);
+
+	cVector3d torque(a_torque);
+	torque.clamp(m_specifications.m_maxAngularTorque);
+
+	double gripperForce = ((a_gripperForce < 0) ? -1 : 1) * std::min(
+		std::abs(a_gripperForce),
+		std::abs(m_specifications.m_maxGripperForce)
+	);
+
     // store new force value.
-    m_prevForce = a_force;
-    m_prevTorque = a_torque;
-    m_prevGripperForce = a_gripperForce;
+    m_prevForce = force;
+    m_prevTorque = torque;
+    m_prevGripperForce = gripperForce;
 
     // retrieve force, torque, and gripper force components in individual variables
-    double fx = a_force(0);
-    double fy = a_force(1);
-    double fz = a_force(2);
+    double fx = force(0);
+    double fy = force(1);
+    double fz = force(2);
 
-    double tx = a_torque(0);
-    double ty = a_torque(1);
-    double tz = a_torque(2);
+    double tx = torque(0);
+    double ty = torque(1);
+    double tz = torque(2);
 
-    double gf = a_gripperForce;
+    double fg = gripperForce;
 
     // *** INSERT YOUR CODE HERE ***
 

--- a/src/devices/CMyCustomDevice.h
+++ b/src/devices/CMyCustomDevice.h
@@ -158,7 +158,7 @@ public:
     virtual bool getUserSwitches(unsigned int& a_userSwitches); 
 
     //! This method sends a force [N] and a torque [N*m] and gripper force [N] to the haptic device.
-    virtual bool setForceAndTorqueAndGripperForce(const cVector3d& a_force, const cVector3d& a_torque, double a_gripperForce);
+    virtual bool setForceAndTorqueAndGripperForce(const cVector3d& a_force, const cVector3d& a_torque, const double a_gripperForce);
 
 
     //--------------------------------------------------------------------------

--- a/src/devices/CPhantomDevices.cpp
+++ b/src/devices/CPhantomDevices.cpp
@@ -797,7 +797,7 @@ bool cPhantomDevice::getRotation(cMatrix3d& a_rotation)
     \return __true__ if the operation succeeds, __false__ otherwise.
 */
 //==============================================================================
-bool cPhantomDevice::setForceAndTorqueAndGripperForce(const cVector3d& a_force, const cVector3d& a_torque, double a_gripperForce)
+bool cPhantomDevice::setForceAndTorqueAndGripperForce(const cVector3d& a_force, const cVector3d& a_torque, const double a_gripperForce)
 {
     // check if drivers are installed
     if (!m_deviceReady)

--- a/src/devices/CPhantomDevices.cpp
+++ b/src/devices/CPhantomDevices.cpp
@@ -805,16 +805,28 @@ bool cPhantomDevice::setForceAndTorqueAndGripperForce(const cVector3d& a_force, 
         return (C_ERROR);
     }
 
+	// clamp forces and torques to prevent device damage
+	cVector3d force(a_force);
+	force.clamp(m_specifications.m_maxLinearForce);
+
+	cVector3d torque(a_torque);
+	torque.clamp(m_specifications.m_maxAngularTorque);
+
+	double gripperForce = ((a_gripperForce < 0) ? -1 : 1) * std::min(
+		std::abs(a_gripperForce),
+		std::abs(m_specifications.m_maxGripperForce)
+	);
+
     // send force and torque command
-    int error = hdPhantomSetForceAndTorque(m_deviceID, &a_force(0), &a_force(1), &a_force(2), &a_torque(0), &a_torque(1), &a_torque(2));
+    int error = hdPhantomSetForceAndTorque(m_deviceID, &force(0), &force(1), &force(2), &torque(0), &torque(1), &torque(2));
     if (error == -1)
     { 
         return (C_ERROR);
     }
 
     // store new commanded values
-    m_prevForce  = a_force;
-    m_prevTorque = a_torque;
+    m_prevForce  = force;
+    m_prevTorque = torque;
 
     // return success
     return (C_SUCCESS);

--- a/src/devices/CPhantomDevices.h
+++ b/src/devices/CPhantomDevices.h
@@ -123,7 +123,7 @@ class cPhantomDevice : public cGenericHapticDevice
     virtual bool getUserSwitches(unsigned int& a_userSwitches); 
 
     //! This method sends a force, torque, and gripper force to the haptic device.
-    virtual bool setForceAndTorqueAndGripperForce(const cVector3d& a_force, const cVector3d& a_torque, double a_gripperForce);
+    virtual bool setForceAndTorqueAndGripperForce(const cVector3d& a_force, const cVector3d& a_torque, const double a_gripperForce);
 
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses issue #2 (limit device forces and torques).

The method signature of `setForceAndTorqueAndGripperForce` declares `a_force` and `a_torque` as const, so I had to create local variables to clamp the vectors. The gripper force is clamped using it's absolute value and `std::min`, then the sign of the original value is applied, to handle negative force commands.

I have tested that this compiles without error in my development environment (Windows 10 64 bit, Visual Studio 2017, compiler version 2015). I will test for any runtime impacts tomorrow.

Importantly, the semantic meaning of `cGenericHapticDevice::m_prevForce`, `cGenericHapticDevice::m_prevTorque` and `cGenericHapticDevice::m_prevGripperForce` have changed subtly in this PR. Previously, these values were simply the previously commanded values. Now, they will return possibly clamped versions of those values. Code that relies on `cGenericHapticDevice::getForce`, `cGenericHapticDevice::getTorque` or `cGenericHapticDevice::getGripperForce` may have downstream effects from this change, especially if dealing with large forces or torques.

If this semantic shift, or the intent behind this PR is too great a change for the project, I could modify this  PR so that `setForceAndTorqueAndGripperForce` takes an optional 4th argument, a boolean flag that enables/disables force/torque clamping. My suggestion is that this is set to 'enable' by default :)

Thanks for the great project.