### PR TITLE
CFileXML.cpp setName() fix

### DIFF
--- a/src/files/CFileXML.cpp
+++ b/src/files/CFileXML.cpp
@@ -475,7 +475,7 @@ bool cFileXML::setName(const string& a_name)
     // otherwise, assign name to current node
     else 
     {
-      ((XML*)(m_xml))->m_currentNode.set_value(a_name.c_str());
+      ((XML*)(m_xml))->m_currentNode.set_name(a_name.c_str());
 
       return true;
     }


### PR DESCRIPTION
When trying to rename a node `cFileXML::setName()` returns `true` as expected, but it does not actually change the node's name. The following snippet shows an example of this issue:

```
// assuming "file" is an instance of cFileXML
file->gotoChild("FirstChild");
file->setName("Stiffness");
```

When `cFileXML::setName()` is called, it seems to use the wrong function from pugixml (see line 478 from *cFileXML.cpp*). Replacing `set_name()` with `set_value()` fixes the issue.