### PR TITLE
Memory Leak Fix

### DIFF
--- a/modules/GEL/src/CGELVertex.cpp
+++ b/modules/GEL/src/CGELVertex.cpp
@@ -74,6 +74,4 @@ cGELVertex::cGELVertex(chai3d::cMesh* a_mesh, unsigned int a_vertexIndex)
 //==========================================================================
 cGELVertex::~cGELVertex()
 {
-    // \todo this causes a crash
-    //delete m_massParticle;
 }

--- a/modules/GEL/src/CGELVertex.cpp
+++ b/modules/GEL/src/CGELVertex.cpp
@@ -45,6 +45,7 @@
 #include "CGELVertex.h"
 //---------------------------------------------------------------------------
 using namespace chai3d;
+using namespace std;
 //---------------------------------------------------------------------------
 
 //===========================================================================
@@ -59,7 +60,7 @@ cGELVertex::cGELVertex(chai3d::cMesh* a_mesh, unsigned int a_vertexIndex)
 {
     m_mesh = a_mesh;
     m_vertexIndex = a_vertexIndex;
-    m_massParticle = new cGELMassParticle();
+    m_massParticle = make_shared<cGELMassParticle>();
     m_link = NULL;
     m_node = NULL;
     m_massParticle->m_pos = a_mesh->m_vertices->getLocalPos(a_vertexIndex);
@@ -74,5 +75,5 @@ cGELVertex::cGELVertex(chai3d::cMesh* a_mesh, unsigned int a_vertexIndex)
 cGELVertex::~cGELVertex()
 {
     // \todo this causes a crash
-    // delete m_massParticle;
+    //delete m_massParticle;
 }

--- a/modules/GEL/src/CGELVertex.h
+++ b/modules/GEL/src/CGELVertex.h
@@ -48,6 +48,7 @@
 #include "CGELMassParticle.h"
 #include "CGELSkeletonLink.h"
 #include "CGELSkeletonNode.h"
+#include <memory>
 //---------------------------------------------------------------------------
 #include "chai3d.h"
 //---------------------------------------------------------------------------
@@ -103,7 +104,7 @@ public:
     chai3d::cMesh* m_mesh;
 
     //! Mass particle for current vertex.
-    cGELMassParticle* m_massParticle;
+    std::shared_ptr<cGELMassParticle> m_massParticle;
 
     //! Skeleton link to which this vertex may be linked to.
     cGELSkeletonLink* m_link;

--- a/src/display/CViewport.cpp
+++ b/src/display/CViewport.cpp
@@ -90,7 +90,6 @@ cViewport::cViewport(cCamera* a_camera, double a_contentScaleWidth, double a_con
 cViewport::~cViewport()
 {
     delete m_cameraViewport;
-    delete m_viewPanel;
 }
 
 


### PR DESCRIPTION
## Issue 1: `cGELVertex` Destructor Crash

In `cGELVertex::~cGELVertex()`, the following line was commented out due to it causing a crash:

```cpp
// delete m_massParticle; // TODO: this causes a crash
```

**Problem:** `m_massParticle` was a raw pointer, but its lifetime was managed/shared elsewhere. Deleting it manually led to a use-after-free or double deletion scenario.

**Fix:** Changed `m_massParticle` from a raw pointer to a `std::shared_ptr<cGELMassParticle>` to ensure automatic reference-counted memory management:

```cpp
std::shared_ptr<cGELMassParticle> m_massParticle;
```

This prevents crashes and safely manages shared ownership.

## Issue 2: `cViewPort` Double Deletion

In `cViewPort::~cViewPort()`, this line attempted to delete `m_viewPanel`:

```cpp
delete m_viewPanel;
```

**Problem:** `m_viewPanel` is a child of `m_frontLayer` (a `cWorld` object), which already deletes all its children via `deleteAllChildren()`. Manually deleting `m_viewPanel` caused a double delete crash.

**Fix:** Removed the manual deletion.

Memory is now correctly handled by `m_frontLayer`'s internal logic.